### PR TITLE
Fix auto-install SOPS key placement

### DIFF
--- a/nixosModules/iso_config.nix
+++ b/nixosModules/iso_config.nix
@@ -36,6 +36,9 @@
     # If the repo lacks hardware‑configuration.nix, uncomment:
     # nixos-generate-config --root /mnt
 
+    # Decrypt the SOPS key so the install can access secrets
+    env HOME=/mnt/root bash /mnt/etc/nixos/scripts/place_sops_key.sh
+
     nixos-install --no-root-passwd --flake /mnt/etc/nixos
     poweroff -f
   '';


### PR DESCRIPTION
## Summary
- ensure installation ISO decrypts SOPS key before running `nixos-install`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6840f9fb1e488327ae09cfc81ac740de